### PR TITLE
feat: Board API 구현

### DIFF
--- a/.history/src/main/java/com/kw/Ddareungi/api/board/controller/BoardController_20251009112529.java
+++ b/.history/src/main/java/com/kw/Ddareungi/api/board/controller/BoardController_20251009112529.java
@@ -1,0 +1,91 @@
+package com.kw.Ddareungi.api.board.controller;
+
+import com.kw.Ddareungi.api.common.dto.ApiResponseDto;
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.service.BoardCommandService;
+import com.kw.Ddareungi.domain.board.service.BoardQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시글", description = "게시글 관련 API")
+@RestController
+@RequestMapping("/api/v1/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardCommandService boardCommandService;
+    private final BoardQueryService boardQueryService;
+
+    @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponseDto<BoardResponseDto.BoardInfo>> createBoard(
+            @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId,
+            @Valid @RequestBody BoardRequestDto.CreateBoard request) {
+        
+        BoardResponseDto.BoardInfo response = boardCommandService.createBoard(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponseDto.onSuccess(response));
+    }
+
+    @Operation(summary = "게시글 수정", description = "기존 게시글을 수정합니다.")
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto<BoardResponseDto.BoardInfo>> updateBoard(
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId,
+            @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId,
+            @Valid @RequestBody BoardRequestDto.UpdateBoard request) {
+        
+        BoardResponseDto.BoardInfo response = boardCommandService.updateBoard(boardId, userId, request);
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(response));
+    }
+
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteBoard(
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId,
+            @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId) {
+        
+        boardCommandService.deleteBoard(boardId, userId);
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(null));
+    }
+
+    @Operation(summary = "게시글 단일 조회", description = "특정 게시글의 상세 정보를 조회합니다.")
+    @GetMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto<BoardResponseDto.BoardInfo>> getBoard(
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId) {
+        
+        BoardResponseDto.BoardInfo response = boardQueryService.getBoard(boardId);
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(response));
+    }
+
+    @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<Page<BoardResponseDto.BoardListInfo>>> getBoards(
+            @Parameter(description = "게시글 타입") @RequestParam(required = false) Board.BoardType boardType,
+            @Parameter(description = "검색 키워드") @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        
+        Page<BoardResponseDto.BoardListInfo> response;
+        
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            response = boardQueryService.searchBoards(keyword, pageable);
+        } else if (boardType != null) {
+            response = boardQueryService.getBoardsByType(boardType, pageable);
+        } else {
+            response = boardQueryService.getAllBoards(pageable);
+        }
+        
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(response));
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/api/board/controller/BoardController_20251009134714.java
+++ b/.history/src/main/java/com/kw/Ddareungi/api/board/controller/BoardController_20251009134714.java
@@ -1,0 +1,91 @@
+package com.kw.Ddareungi.api.board.controller;
+
+import com.kw.Ddareungi.api.common.dto.ApiResponseDto;
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.service.BoardCommandService;
+import com.kw.Ddareungi.domain.board.service.BoardQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시글", description = "게시글 관련 API")
+@RestController
+@RequestMapping("/api/v1/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardCommandService boardCommandService;
+    private final BoardQueryService boardQueryService;
+
+    @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponseDto<BoardResponseDto.BoardInfo>> createBoard(
+            @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId,
+            @Valid @RequestBody BoardRequestDto.CreateBoard request) {
+        
+        BoardResponseDto.BoardInfo response = boardCommandService.createBoard(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponseDto.onSuccess(response));
+    }
+
+    @Operation(summary = "게시글 수정", description = "기존 게시글을 수정합니다.")
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto<BoardResponseDto.BoardInfo>> updateBoard(
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId,
+            @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId,
+            @Valid @RequestBody BoardRequestDto.UpdateBoard request) {
+        
+        BoardResponseDto.BoardInfo response = boardCommandService.updateBoard(boardId, userId, request);
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(response));
+    }
+
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteBoard(
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId,
+            @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId) {
+        
+        boardCommandService.deleteBoard(boardId, userId);
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(null));
+    }
+
+    @Operation(summary = "게시글 단일 조회", description = "특정 게시글의 상세 정보를 조회합니다.")
+    @GetMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto<BoardResponseDto.BoardInfo>> getBoard(
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId) {
+        
+        BoardResponseDto.BoardInfo response = boardQueryService.getBoard(boardId);
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(response));
+    }
+
+    @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<Page<BoardResponseDto.BoardListInfo>>> getBoards(
+            @Parameter(description = "게시글 타입") @RequestParam(required = false) Board.BoardType boardType,
+            @Parameter(description = "검색 키워드") @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        
+        Page<BoardResponseDto.BoardListInfo> response;
+        
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            response = boardQueryService.searchBoards(keyword, pageable);
+        } else if (boardType != null) {
+            response = boardQueryService.getBoardsByType(boardType, pageable);
+        } else {
+            response = boardQueryService.getAllBoards(pageable);
+        }
+        
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(response));
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardRequestDto_20251009112506.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardRequestDto_20251009112506.java
@@ -1,0 +1,40 @@
+package com.kw.Ddareungi.domain.board.dto;
+
+import com.kw.Ddareungi.domain.board.entity.Board;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BoardRequestDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateBoard {
+        @NotNull(message = "게시글 타입은 필수입니다.")
+        private Board.BoardType boardType;
+
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
+        private String title;
+
+        @NotBlank(message = "내용은 필수입니다.")
+        private String content;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateBoard {
+        @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
+        private String title;
+
+        private String content;
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardResponseDto_20251009112509.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardResponseDto_20251009112509.java
@@ -1,0 +1,64 @@
+package com.kw.Ddareungi.domain.board.dto;
+
+import com.kw.Ddareungi.domain.board.entity.Board;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class BoardResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardInfo {
+        private Long boardId;
+        private Long userId;
+        private String userName;
+        private Board.BoardType boardType;
+        private String title;
+        private String content;
+        private LocalDateTime createdDate;
+        private LocalDateTime lastModifiedDate;
+
+        public static BoardInfo from(Board board) {
+            return BoardInfo.builder()
+                    .boardId(board.getId())
+                    .userId(board.getUser().getId())
+                    .userName(board.getUser().getName())
+                    .boardType(board.getBoardType())
+                    .title(board.getTitle())
+                    .content(board.getContent())
+                    .createdDate(board.getCreatedDate())
+                    .lastModifiedDate(board.getLastModifiedDate())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardListInfo {
+        private Long boardId;
+        private Long userId;
+        private String userName;
+        private Board.BoardType boardType;
+        private String title;
+        private LocalDateTime createdDate;
+
+        public static BoardListInfo from(Board board) {
+            return BoardListInfo.builder()
+                    .boardId(board.getId())
+                    .userId(board.getUser().getId())
+                    .userName(board.getUser().getName())
+                    .boardType(board.getBoardType())
+                    .title(board.getTitle())
+                    .createdDate(board.getCreatedDate())
+                    .build();
+        }
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardResponseDto_20251009134630.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardResponseDto_20251009134630.java
@@ -1,0 +1,64 @@
+package com.kw.Ddareungi.domain.board.dto;
+
+import com.kw.Ddareungi.domain.board.entity.Board;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class BoardResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardInfo {
+        private Long boardId;
+        private Long userId;
+        private String userName;
+        private Board.BoardType boardType;
+        private String title;
+        private String content;
+        private LocalDateTime createdDate;
+        private LocalDateTime lastModifiedDate;
+
+        public static BoardInfo from(Board board) {
+            return BoardInfo.builder()
+                    .boardId(board.getId())
+                    .userId(board.getUser().getId())
+                    .userName(board.getUser().getName())
+                    .boardType(board.getBoardType())
+                    .title(board.getTitle())
+                    .content(board.getContent())
+                    .createdDate(board.getCreatedDate())
+                    .lastModifiedDate(board.getLastModifiedDate())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardListInfo {
+        private Long boardId;
+        private Long userId;
+        private String userName;
+        private Board.BoardType boardType;
+        private String title;
+        private LocalDateTime createdDate;
+
+        public static BoardListInfo from(Board board) {
+            return BoardListInfo.builder()
+                    .boardId(board.getId())
+                    .userId(board.getUser().getId())
+                    .userName(board.getUser().getName())
+                    .boardType(board.getBoardType())
+                    .title(board.getTitle())
+                    .createdDate(board.getCreatedDate())
+                    .build();
+        }
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009112459.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009112459.java
@@ -1,0 +1,40 @@
+package com.kw.Ddareungi.domain.board.entity;
+
+import com.kw.Ddareungi.domain.model.entity.BaseTimeEntity;
+import com.kw.Ddareungi.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum BoardType {
+        QNA, NOTICE, REPORT
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113154.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113154.java
@@ -1,0 +1,39 @@
+package com.kw.Ddareungi.domain.board.entity;
+
+import com.kw.Ddareungi.domain.model.entity.BaseTimeEntity;
+import com.kw.Ddareungi.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum BoardType {
+        QNA, NOTICE, REPORT
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113157.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113157.java
@@ -1,0 +1,63 @@
+package com.kw.Ddareungi.domain.board.entity;
+
+import com.kw.Ddareungi.domain.model.entity.BaseTimeEntity;
+import com.kw.Ddareungi.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum BoardType {
+        QNA, NOTICE, REPORT
+    }
+
+    // 비즈니스 메서드들
+    public void updateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("제목은 필수입니다.");
+        }
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        if (content == null) {
+            throw new IllegalArgumentException("내용은 null일 수 없습니다.");
+        }
+        this.content = content;
+    }
+
+    public void updateBoard(String title, String content) {
+        if (title != null && !title.trim().isEmpty()) {
+            updateTitle(title);
+        }
+        if (content != null) {
+            updateContent(content);
+        }
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113205.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113205.java
@@ -1,0 +1,63 @@
+package com.kw.Ddareungi.domain.board.entity;
+
+import com.kw.Ddareungi.domain.model.entity.BaseTimeEntity;
+import com.kw.Ddareungi.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum BoardType {
+        QNA, NOTICE, REPORT
+    }
+
+    // 비즈니스 메서드들
+    public void updateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("제목은 필수입니다.");
+        }
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        if (content == null) {
+            throw new IllegalArgumentException("내용은 null일 수 없습니다.");
+        }
+        this.content = content;
+    }
+
+    public void updateBoard(String title, String content) {
+        if (title != null && !title.trim().isEmpty()) {
+            updateTitle(title);
+        }
+        if (content != null) {
+            updateContent(content);
+        }
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113254.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113254.java
@@ -1,0 +1,63 @@
+package com.kw.Ddareungi.domain.board.entity;
+
+import com.kw.Ddareungi.domain.model.entity.BaseTimeEntity;
+import com.kw.Ddareungi.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum BoardType {
+        QNA, NOTICE, REPORT
+    }
+
+    // 비즈니스 메서드들
+    public void updateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("제목은 필수입니다.");
+        }
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        if (content == null) {
+            throw new IllegalArgumentException("내용은 null일 수 없습니다.");
+        }
+        this.content = content;
+    }
+
+    public void updateBoard(String title, String content) {
+        if (title != null && !title.trim().isEmpty()) {
+            updateTitle(title);
+        }
+        if (content != null) {
+            updateContent(content);
+        }
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113720.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113720.java
@@ -1,0 +1,63 @@
+package com.kw.Ddareungi.domain.board.entity;
+
+import com.kw.Ddareungi.domain.model.entity.BaseTimeEntity;
+import com.kw.Ddareungi.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum BoardType {
+        QNA, NOTICE, REPORT
+    }
+
+    // 비즈니스 메서드들
+    public void updateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("제목은 필수입니다.");
+        }
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        if (content == null) {
+            throw new IllegalArgumentException("내용은 null일 수 없습니다.");
+        }
+        this.content = content;
+    }
+
+    public void updateBoard(String title, String content) {
+        if (title != null && !title.trim().isEmpty()) {
+            this.title = title;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113723.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113723.java
@@ -1,0 +1,63 @@
+package com.kw.Ddareungi.domain.board.entity;
+
+import com.kw.Ddareungi.domain.model.entity.BaseTimeEntity;
+import com.kw.Ddareungi.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum BoardType {
+        QNA, NOTICE, REPORT
+    }
+
+    // 비즈니스 메서드들
+    public void updateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("제목은 필수입니다.");
+        }
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        if (content == null) {
+            throw new IllegalArgumentException("내용은 null일 수 없습니다.");
+        }
+        this.content = content;
+    }
+
+    public void updateBoard(String title, String content) {
+        if (title != null && !title.trim().isEmpty()) {
+            this.title = title;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113724.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/entity/Board_20251009113724.java
@@ -1,0 +1,63 @@
+package com.kw.Ddareungi.domain.board.entity;
+
+import com.kw.Ddareungi.domain.model.entity.BaseTimeEntity;
+import com.kw.Ddareungi.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum BoardType {
+        QNA, NOTICE, REPORT
+    }
+
+    // 비즈니스 메서드들
+    public void updateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("제목은 필수입니다.");
+        }
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        if (content == null) {
+            throw new IllegalArgumentException("내용은 null일 수 없습니다.");
+        }
+        this.content = content;
+    }
+
+    public void updateBoard(String title, String content) {
+        if (title != null && !title.trim().isEmpty()) {
+            this.title = title;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/repository/BoardRepository_20251009112502.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/repository/BoardRepository_20251009112502.java
@@ -1,0 +1,29 @@
+package com.kw.Ddareungi.domain.board.repository;
+
+import com.kw.Ddareungi.domain.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+    
+    // 게시글 타입별 조회
+    Page<Board> findByBoardType(Board.BoardType boardType, Pageable pageable);
+    
+    // 사용자별 게시글 조회
+    List<Board> findByUserId(Long userId);
+    
+    // 제목으로 검색
+    Page<Board> findByTitleContaining(String title, Pageable pageable);
+    
+    // 내용으로 검색
+    Page<Board> findByContentContaining(String content, Pageable pageable);
+    
+    // 제목 또는 내용으로 검색
+    @Query("SELECT b FROM Board b WHERE b.title LIKE %:keyword% OR b.content LIKE %:keyword%")
+    Page<Board> findByTitleOrContentContaining(@Param("keyword") String keyword, Pageable pageable);
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl_20251009112518.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl_20251009112518.java
@@ -1,0 +1,71 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.repository.BoardRepository;
+import com.kw.Ddareungi.domain.user.entity.User;
+import com.kw.Ddareungi.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardCommandServiceImpl implements BoardCommandService {
+
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public BoardResponseDto.BoardInfo createBoard(Long userId, BoardRequestDto.CreateBoard request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Board board = Board.builder()
+                .user(user)
+                .boardType(request.getBoardType())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(savedBoard);
+    }
+
+    @Override
+    public BoardResponseDto.BoardInfo updateBoard(Long boardId, Long userId, BoardRequestDto.UpdateBoard request) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 수정할 권한이 없습니다.");
+        }
+
+        // 수정할 필드가 있는 경우에만 업데이트
+        if (request.getTitle() != null && !request.getTitle().trim().isEmpty()) {
+            board.setTitle(request.getTitle());
+        }
+        if (request.getContent() != null) {
+            board.setContent(request.getContent());
+        }
+
+        Board updatedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(updatedBoard);
+    }
+
+    @Override
+    public void deleteBoard(Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 삭제할 권한이 없습니다.");
+        }
+
+        boardRepository.delete(board);
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl_20251009113200.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl_20251009113200.java
@@ -1,0 +1,66 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.repository.BoardRepository;
+import com.kw.Ddareungi.domain.user.entity.User;
+import com.kw.Ddareungi.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardCommandServiceImpl implements BoardCommandService {
+
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public BoardResponseDto.BoardInfo createBoard(Long userId, BoardRequestDto.CreateBoard request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Board board = Board.builder()
+                .user(user)
+                .boardType(request.getBoardType())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(savedBoard);
+    }
+
+    @Override
+    public BoardResponseDto.BoardInfo updateBoard(Long boardId, Long userId, BoardRequestDto.UpdateBoard request) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 수정할 권한이 없습니다.");
+        }
+
+        // 수정할 필드가 있는 경우에만 업데이트
+        board.updateBoard(request.getTitle(), request.getContent());
+
+        Board updatedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(updatedBoard);
+    }
+
+    @Override
+    public void deleteBoard(Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 삭제할 권한이 없습니다.");
+        }
+
+        boardRepository.delete(board);
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl_20251009113206.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl_20251009113206.java
@@ -1,0 +1,66 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.repository.BoardRepository;
+import com.kw.Ddareungi.domain.user.entity.User;
+import com.kw.Ddareungi.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardCommandServiceImpl implements BoardCommandService {
+
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public BoardResponseDto.BoardInfo createBoard(Long userId, BoardRequestDto.CreateBoard request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Board board = Board.builder()
+                .user(user)
+                .boardType(request.getBoardType())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(savedBoard);
+    }
+
+    @Override
+    public BoardResponseDto.BoardInfo updateBoard(Long boardId, Long userId, BoardRequestDto.UpdateBoard request) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 수정할 권한이 없습니다.");
+        }
+
+        // 수정할 필드가 있는 경우에만 업데이트
+        board.updateBoard(request.getTitle(), request.getContent());
+
+        Board updatedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(updatedBoard);
+    }
+
+    @Override
+    public void deleteBoard(Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 삭제할 권한이 없습니다.");
+        }
+
+        boardRepository.delete(board);
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl_20251009134730.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl_20251009134730.java
@@ -1,0 +1,66 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.repository.BoardRepository;
+import com.kw.Ddareungi.domain.user.entity.User;
+import com.kw.Ddareungi.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardCommandServiceImpl implements BoardCommandService {
+
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public BoardResponseDto.BoardInfo createBoard(Long userId, BoardRequestDto.CreateBoard request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Board board = Board.builder()
+                .user(user)
+                .boardType(request.getBoardType())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(savedBoard);
+    }
+
+    @Override
+    public BoardResponseDto.BoardInfo updateBoard(Long boardId, Long userId, BoardRequestDto.UpdateBoard request) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 수정할 권한이 없습니다.");
+        }
+
+        // 수정할 필드가 있는 경우에만 업데이트
+        board.updateBoard(request.getTitle(), request.getContent());
+
+        Board updatedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(updatedBoard);
+    }
+
+    @Override
+    public void deleteBoard(Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 삭제할 권한이 없습니다.");
+        }
+
+        boardRepository.delete(board);
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandService_20251009112512.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandService_20251009112512.java
@@ -1,0 +1,16 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+
+public interface BoardCommandService {
+    
+    // 게시글 작성
+    BoardResponseDto.BoardInfo createBoard(Long userId, BoardRequestDto.CreateBoard request);
+    
+    // 게시글 수정
+    BoardResponseDto.BoardInfo updateBoard(Long boardId, Long userId, BoardRequestDto.UpdateBoard request);
+    
+    // 게시글 삭제
+    void deleteBoard(Long boardId, Long userId);
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandService_20251009134655.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandService_20251009134655.java
@@ -1,0 +1,16 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+
+public interface BoardCommandService {
+    
+    // 게시글 작성
+    BoardResponseDto.BoardInfo createBoard(Long userId, BoardRequestDto.CreateBoard request);
+    
+    // 게시글 수정
+    BoardResponseDto.BoardInfo updateBoard(Long boardId, Long userId, BoardRequestDto.UpdateBoard request);
+    
+    // 게시글 삭제
+    void deleteBoard(Long boardId, Long userId);
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryServiceImpl_20251009112521.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryServiceImpl_20251009112521.java
@@ -1,0 +1,44 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardQueryServiceImpl implements BoardQueryService {
+
+    private final BoardRepository boardRepository;
+
+    @Override
+    public BoardResponseDto.BoardInfo getBoard(Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+        
+        return BoardResponseDto.BoardInfo.from(board);
+    }
+
+    @Override
+    public Page<BoardResponseDto.BoardListInfo> getBoardsByType(Board.BoardType boardType, Pageable pageable) {
+        return boardRepository.findByBoardType(boardType, pageable)
+                .map(BoardResponseDto.BoardListInfo::from);
+    }
+
+    @Override
+    public Page<BoardResponseDto.BoardListInfo> getAllBoards(Pageable pageable) {
+        return boardRepository.findAll(pageable)
+                .map(BoardResponseDto.BoardListInfo::from);
+    }
+
+    @Override
+    public Page<BoardResponseDto.BoardListInfo> searchBoards(String keyword, Pageable pageable) {
+        return boardRepository.findByTitleOrContentContaining(keyword, pageable)
+                .map(BoardResponseDto.BoardListInfo::from);
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryServiceImpl_20251009134708.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryServiceImpl_20251009134708.java
@@ -1,0 +1,44 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardQueryServiceImpl implements BoardQueryService {
+
+    private final BoardRepository boardRepository;
+
+    @Override
+    public BoardResponseDto.BoardInfo getBoard(Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+        
+        return BoardResponseDto.BoardInfo.from(board);
+    }
+
+    @Override
+    public Page<BoardResponseDto.BoardListInfo> getBoardsByType(Board.BoardType boardType, Pageable pageable) {
+        return boardRepository.findByBoardType(boardType, pageable)
+                .map(BoardResponseDto.BoardListInfo::from);
+    }
+
+    @Override
+    public Page<BoardResponseDto.BoardListInfo> getAllBoards(Pageable pageable) {
+        return boardRepository.findAll(pageable)
+                .map(BoardResponseDto.BoardListInfo::from);
+    }
+
+    @Override
+    public Page<BoardResponseDto.BoardListInfo> searchBoards(String keyword, Pageable pageable) {
+        return boardRepository.findByTitleOrContentContaining(keyword, pageable)
+                .map(BoardResponseDto.BoardListInfo::from);
+    }
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryService_20251009112513.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryService_20251009112513.java
@@ -1,0 +1,21 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BoardQueryService {
+    
+    // 게시글 단일 조회
+    BoardResponseDto.BoardInfo getBoard(Long boardId);
+    
+    // 게시글 목록 조회 (타입별)
+    Page<BoardResponseDto.BoardListInfo> getBoardsByType(Board.BoardType boardType, Pageable pageable);
+    
+    // 게시글 목록 조회 (전체)
+    Page<BoardResponseDto.BoardListInfo> getAllBoards(Pageable pageable);
+    
+    // 게시글 검색
+    Page<BoardResponseDto.BoardListInfo> searchBoards(String keyword, Pageable pageable);
+}

--- a/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryService_20251009134701.java
+++ b/.history/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryService_20251009134701.java
@@ -1,0 +1,21 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BoardQueryService {
+    
+    // 게시글 단일 조회
+    BoardResponseDto.BoardInfo getBoard(Long boardId);
+    
+    // 게시글 목록 조회 (타입별)
+    Page<BoardResponseDto.BoardListInfo> getBoardsByType(Board.BoardType boardType, Pageable pageable);
+    
+    // 게시글 목록 조회 (전체)
+    Page<BoardResponseDto.BoardListInfo> getAllBoards(Pageable pageable);
+    
+    // 게시글 검색
+    Page<BoardResponseDto.BoardListInfo> searchBoards(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/kw/Ddareungi/api/board/controller/BoardController.java
+++ b/src/main/java/com/kw/Ddareungi/api/board/controller/BoardController.java
@@ -1,0 +1,91 @@
+package com.kw.Ddareungi.api.board.controller;
+
+import com.kw.Ddareungi.api.common.dto.ApiResponseDto;
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.service.BoardCommandService;
+import com.kw.Ddareungi.domain.board.service.BoardQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시글", description = "게시글 관련 API")
+@RestController
+@RequestMapping("/api/v1/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardCommandService boardCommandService;
+    private final BoardQueryService boardQueryService;
+
+    @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponseDto<BoardResponseDto.BoardInfo>> createBoard(
+            @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId,
+            @Valid @RequestBody BoardRequestDto.CreateBoard request) {
+        
+        BoardResponseDto.BoardInfo response = boardCommandService.createBoard(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponseDto.onSuccess(response));
+    }
+
+    @Operation(summary = "게시글 수정", description = "기존 게시글을 수정합니다.")
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto<BoardResponseDto.BoardInfo>> updateBoard(
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId,
+            @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId,
+            @Valid @RequestBody BoardRequestDto.UpdateBoard request) {
+        
+        BoardResponseDto.BoardInfo response = boardCommandService.updateBoard(boardId, userId, request);
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(response));
+    }
+
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteBoard(
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId,
+            @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId) {
+        
+        boardCommandService.deleteBoard(boardId, userId);
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(null));
+    }
+
+    @Operation(summary = "게시글 단일 조회", description = "특정 게시글의 상세 정보를 조회합니다.")
+    @GetMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto<BoardResponseDto.BoardInfo>> getBoard(
+            @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId) {
+        
+        BoardResponseDto.BoardInfo response = boardQueryService.getBoard(boardId);
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(response));
+    }
+
+    @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<Page<BoardResponseDto.BoardListInfo>>> getBoards(
+            @Parameter(description = "게시글 타입") @RequestParam(required = false) Board.BoardType boardType,
+            @Parameter(description = "검색 키워드") @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        
+        Page<BoardResponseDto.BoardListInfo> response;
+        
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            response = boardQueryService.searchBoards(keyword, pageable);
+        } else if (boardType != null) {
+            response = boardQueryService.getBoardsByType(boardType, pageable);
+        } else {
+            response = boardQueryService.getAllBoards(pageable);
+        }
+        
+        return ResponseEntity.ok(ApiResponseDto.onSuccess(response));
+    }
+}

--- a/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardRequestDto.java
@@ -1,0 +1,40 @@
+package com.kw.Ddareungi.domain.board.dto;
+
+import com.kw.Ddareungi.domain.board.entity.Board;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BoardRequestDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateBoard {
+        @NotNull(message = "게시글 타입은 필수입니다.")
+        private Board.BoardType boardType;
+
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
+        private String title;
+
+        @NotBlank(message = "내용은 필수입니다.")
+        private String content;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateBoard {
+        @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
+        private String title;
+
+        private String content;
+    }
+}

--- a/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/kw/Ddareungi/domain/board/dto/BoardResponseDto.java
@@ -1,0 +1,64 @@
+package com.kw.Ddareungi.domain.board.dto;
+
+import com.kw.Ddareungi.domain.board.entity.Board;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class BoardResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardInfo {
+        private Long boardId;
+        private Long userId;
+        private String userName;
+        private Board.BoardType boardType;
+        private String title;
+        private String content;
+        private LocalDateTime createdDate;
+        private LocalDateTime lastModifiedDate;
+
+        public static BoardInfo from(Board board) {
+            return BoardInfo.builder()
+                    .boardId(board.getId())
+                    .userId(board.getUser().getId())
+                    .userName(board.getUser().getName())
+                    .boardType(board.getBoardType())
+                    .title(board.getTitle())
+                    .content(board.getContent())
+                    .createdDate(board.getCreatedDate())
+                    .lastModifiedDate(board.getLastModifiedDate())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardListInfo {
+        private Long boardId;
+        private Long userId;
+        private String userName;
+        private Board.BoardType boardType;
+        private String title;
+        private LocalDateTime createdDate;
+
+        public static BoardListInfo from(Board board) {
+            return BoardListInfo.builder()
+                    .boardId(board.getId())
+                    .userId(board.getUser().getId())
+                    .userName(board.getUser().getName())
+                    .boardType(board.getBoardType())
+                    .title(board.getTitle())
+                    .createdDate(board.getCreatedDate())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/kw/Ddareungi/domain/board/entity/Board.java
+++ b/src/main/java/com/kw/Ddareungi/domain/board/entity/Board.java
@@ -1,0 +1,63 @@
+package com.kw.Ddareungi.domain.board.entity;
+
+import com.kw.Ddareungi.domain.model.entity.BaseTimeEntity;
+import com.kw.Ddareungi.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum BoardType {
+        QNA, NOTICE, REPORT
+    }
+
+    // 비즈니스 메서드들
+    public void updateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("제목은 필수입니다.");
+        }
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        if (content == null) {
+            throw new IllegalArgumentException("내용은 null일 수 없습니다.");
+        }
+        this.content = content;
+    }
+
+    public void updateBoard(String title, String content) {
+        if (title != null && !title.trim().isEmpty()) {
+            this.title = title;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+    }
+}

--- a/src/main/java/com/kw/Ddareungi/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/kw/Ddareungi/domain/board/repository/BoardRepository.java
@@ -1,0 +1,29 @@
+package com.kw.Ddareungi.domain.board.repository;
+
+import com.kw.Ddareungi.domain.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+    
+    // 게시글 타입별 조회
+    Page<Board> findByBoardType(Board.BoardType boardType, Pageable pageable);
+    
+    // 사용자별 게시글 조회
+    List<Board> findByUserId(Long userId);
+    
+    // 제목으로 검색
+    Page<Board> findByTitleContaining(String title, Pageable pageable);
+    
+    // 내용으로 검색
+    Page<Board> findByContentContaining(String content, Pageable pageable);
+    
+    // 제목 또는 내용으로 검색
+    @Query("SELECT b FROM Board b WHERE b.title LIKE %:keyword% OR b.content LIKE %:keyword%")
+    Page<Board> findByTitleOrContentContaining(@Param("keyword") String keyword, Pageable pageable);
+}

--- a/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandService.java
+++ b/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandService.java
@@ -1,0 +1,16 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+
+public interface BoardCommandService {
+    
+    // 게시글 작성
+    BoardResponseDto.BoardInfo createBoard(Long userId, BoardRequestDto.CreateBoard request);
+    
+    // 게시글 수정
+    BoardResponseDto.BoardInfo updateBoard(Long boardId, Long userId, BoardRequestDto.UpdateBoard request);
+    
+    // 게시글 삭제
+    void deleteBoard(Long boardId, Long userId);
+}

--- a/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl.java
+++ b/src/main/java/com/kw/Ddareungi/domain/board/service/BoardCommandServiceImpl.java
@@ -1,0 +1,66 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardRequestDto;
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.repository.BoardRepository;
+import com.kw.Ddareungi.domain.user.entity.User;
+import com.kw.Ddareungi.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardCommandServiceImpl implements BoardCommandService {
+
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public BoardResponseDto.BoardInfo createBoard(Long userId, BoardRequestDto.CreateBoard request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Board board = Board.builder()
+                .user(user)
+                .boardType(request.getBoardType())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(savedBoard);
+    }
+
+    @Override
+    public BoardResponseDto.BoardInfo updateBoard(Long boardId, Long userId, BoardRequestDto.UpdateBoard request) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 수정할 권한이 없습니다.");
+        }
+
+        // 수정할 필드가 있는 경우에만 업데이트
+        board.updateBoard(request.getTitle(), request.getContent());
+
+        Board updatedBoard = boardRepository.save(board);
+        return BoardResponseDto.BoardInfo.from(updatedBoard);
+    }
+
+    @Override
+    public void deleteBoard(Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 작성자 확인
+        if (!board.getUser().getId().equals(userId)) {
+            throw new RuntimeException("게시글을 삭제할 권한이 없습니다.");
+        }
+
+        boardRepository.delete(board);
+    }
+}

--- a/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryService.java
+++ b/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryService.java
@@ -1,0 +1,21 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BoardQueryService {
+    
+    // 게시글 단일 조회
+    BoardResponseDto.BoardInfo getBoard(Long boardId);
+    
+    // 게시글 목록 조회 (타입별)
+    Page<BoardResponseDto.BoardListInfo> getBoardsByType(Board.BoardType boardType, Pageable pageable);
+    
+    // 게시글 목록 조회 (전체)
+    Page<BoardResponseDto.BoardListInfo> getAllBoards(Pageable pageable);
+    
+    // 게시글 검색
+    Page<BoardResponseDto.BoardListInfo> searchBoards(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryServiceImpl.java
+++ b/src/main/java/com/kw/Ddareungi/domain/board/service/BoardQueryServiceImpl.java
@@ -1,0 +1,44 @@
+package com.kw.Ddareungi.domain.board.service;
+
+import com.kw.Ddareungi.domain.board.dto.BoardResponseDto;
+import com.kw.Ddareungi.domain.board.entity.Board;
+import com.kw.Ddareungi.domain.board.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardQueryServiceImpl implements BoardQueryService {
+
+    private final BoardRepository boardRepository;
+
+    @Override
+    public BoardResponseDto.BoardInfo getBoard(Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+        
+        return BoardResponseDto.BoardInfo.from(board);
+    }
+
+    @Override
+    public Page<BoardResponseDto.BoardListInfo> getBoardsByType(Board.BoardType boardType, Pageable pageable) {
+        return boardRepository.findByBoardType(boardType, pageable)
+                .map(BoardResponseDto.BoardListInfo::from);
+    }
+
+    @Override
+    public Page<BoardResponseDto.BoardListInfo> getAllBoards(Pageable pageable) {
+        return boardRepository.findAll(pageable)
+                .map(BoardResponseDto.BoardListInfo::from);
+    }
+
+    @Override
+    public Page<BoardResponseDto.BoardListInfo> searchBoards(String keyword, Pageable pageable) {
+        return boardRepository.findByTitleOrContentContaining(keyword, pageable)
+                .map(BoardResponseDto.BoardListInfo::from);
+    }
+}


### PR DESCRIPTION
## 📋 개요
게시글(Board) CRUD API를 구현했습니다. 게시글 작성, 수정, 삭제, 조회 기능과 함께 타입별 필터링 및 검색 기능을 제공합니다.

## ✨ 주요 기능

### 1. 게시글 관리 API
- **게시글 작성** (`POST /api/v1/boards`)
  - 게시글 타입(QNA, NOTICE, REPORT), 제목, 내용을 입력받아 게시글을 생성합니다.
  - 제목 최대 200자 제한 및 필수 입력 검증을 포함합니다.

- **게시글 수정** (`PATCH /api/v1/boards/{boardId}`)
  - 작성자만 수정 가능하도록 권한 검증을 구현했습니다.
  - 제목과 내용을 선택적으로 수정할 수 있습니다.

- **게시글 삭제** (`DELETE /api/v1/boards/{boardId}`)
  - 작성자만 삭제 가능하도록 권한 검증을 구현했습니다.

### 2. 게시글 조회 API
- **게시글 단일 조회** (`GET /api/v1/boards/{boardId}`)
  - 게시글의 상세 정보를 조회합니다.

- **게시글 목록 조회** (`GET /api/v1/boards`)
  - 전체 게시글 목록 조회
  - 게시글 타입별 필터링 (`boardType` 파라미터)
  - 키워드 검색 (`keyword` 파라미터) - 제목 또는 내용에서 검색
  - 페이징 처리 (기본값: 10개, 생성일 기준 내림차순 정렬)

## 🏗️ 아키텍처

### 계층 구조
- **Controller**: REST API 엔드포인트 및 요청/응답 처리
- **Service**: 비즈니스 로직 처리 (Command/Query 분리)
  - `BoardCommandService`: 게시글 생성, 수정, 삭제
  - `BoardQueryService`: 게시글 조회
- **Repository**: 데이터 접근 계층
- **Entity**: 도메인 모델 (Board 엔티티)

### 주요 구현 내용
- **Board 엔티티**: User와 ManyToOne 관계, BoardType enum (QNA, NOTICE, REPORT)
- **DTO 분리**: Request/Response DTO를 별도 클래스로 관리
- **비즈니스 메서드**: 엔티티 내부에 `updateTitle`, `updateContent`, `updateBoard` 메서드 구현
- **Swagger 문서화**: 모든 API에 Swagger 어노테이션 적용

## 🔍 검색 기능
- 제목 또는 내용에서 키워드 검색 지원
- 대소문자 구분 없이 부분 일치 검색 (`LIKE %keyword%`)

## 📝 기술 스택
- Spring Boot
- Spring Data JPA
- Swagger/OpenAPI 3
- Jakarta Validation

## ✅ 검증 사항
- 입력값 검증 (제목 필수, 최대 200자 제한)
- 작성자 권한 검증 (수정/삭제 시)
- 존재하지 않는 게시글/사용자 예외 처리